### PR TITLE
Fix incorrect use of delProperty() and __del__() (of class Properties)

### DIFF
--- a/lookml/lookml.py
+++ b/lookml/lookml.py
@@ -379,7 +379,7 @@ class base(object):
 
     def unHide(self):
         ''''''
-        self.properties.delProperty('hidden')
+        self.properties.removeProperty('hidden')
         return self
 
     def setMessage(self,message):
@@ -403,7 +403,7 @@ class base(object):
 
     def unSetProperty(self, name):
         ''''''
-        self.properties.__del__(name)
+        self.properties.removeProperty(name)
         return self
 
     def getProperties(self):
@@ -1521,7 +1521,7 @@ class Properties(object):
         else:
             self.schema.update({name: value})
 
-    def __delete__(self, identifier):
+    def removeProperty(self, identifier):
         if isinstance(self.schema,dict):
             self.schema.pop(identifier, None)
         elif isinstance(self.schema,list):


### PR DESCRIPTION
Fix use of delProperty() and __del__() (of class Properties) which are not defined, and rename the method to be a regular one, instead of __delete__()
